### PR TITLE
Added support for the new identity expectation value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 env:
   - LOGGING=info
 install:
+  - pip install -e git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
   - pip install -r requirements.txt
   - pip install pytest pytest-cov wheel codecov
   - python3 setup.py bdist_wheel

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -83,7 +83,7 @@ Supported operations
 
 	* **Supported operations:** ``Beamsplitter``, ``ControlledAddition``, ``ControlledPhase``, ``Displacement``, ``Kerr``, ``CrossKerr``, ``QuadraticPhase``, ``Rotation``, ``Squeezing``, ``TwoModeSqueezing``, ``CubicPhase``, ``CatState``, ``CoherentState``, ``FockDensityMatrix``, ``DisplacedSqueezedState``, ``FockState``, ``FockStateVector``, ``SqueezedState``, ``ThermalState``, ``GaussianState``
 
-	* **Supported expectations:** ``MeanPhoton``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
+	* **Supported expectations:** ``Identity``, ``MeanPhoton``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
 
 
 :class:`strawberryfields.gaussian <~StrawberryFieldsGaussian>`
@@ -92,4 +92,4 @@ Supported operations
 
 	* **Supported operations:** ``Beamsplitter``, ``ControlledAddition``, ``ControlledPhase``, ``Displacement``, ``QuadraticPhase``, ``Rotation``, ``Squeezing``, ``TwoModeSqueezing``, ``CoherentState``, ``DisplacedSqueezedState``, ``SqueezedState``, ``ThermalState``, ``GaussianState``
 
-	* **Supported expectations:** ``MeanPhoton``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
+	* **Supported expectations:** ``Identity``, ``MeanPhoton``, ``X``, ``P``, ``Homodyne``, ``PolyXP``

--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -23,6 +23,7 @@ Contains auxillary functions which convert from PennyLane-style expectations,
 to the corresponding state methods in Strawberry Fields.
 
 .. autosummary::
+    identity
     mean_photon
     number_state
     homodyne

--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -40,7 +40,7 @@ from strawberryfields.ops import (Catstate, Coherent, DensityMatrix, DisplacedSq
 from strawberryfields.ops import (BSgate, CKgate, CXgate, CZgate, Dgate,
                                   Kgate, Pgate, Rgate, S2gate, Sgate, Vgate)
 
-from .expectations import (mean_photon, homodyne, number_state, poly_xp)
+from .expectations import (identity, mean_photon, homodyne, number_state, poly_xp)
 from .simulator import StrawberryFieldsSimulator
 
 
@@ -88,7 +88,8 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
         'P': homodyne(np.pi/2),
         'Homodyne': homodyne(),
         'PolyXP': poly_xp,
-        'NumberState': number_state
+        'NumberState': number_state,
+        'Identity': identity
     }
 
     _circuits = {}

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -42,7 +42,7 @@ from strawberryfields.ops import (Coherent, DisplacedSqueezed,
 from strawberryfields.ops import (BSgate, CXgate, CZgate, Dgate,
                                   Pgate, Rgate, S2gate, Sgate)
 
-from .expectations import (mean_photon, homodyne, number_state, poly_xp)
+from .expectations import (identity, mean_photon, homodyne, number_state, poly_xp)
 from .simulator import StrawberryFieldsSimulator
 
 
@@ -74,7 +74,8 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
         'P': homodyne(np.pi/2),
         'Homodyne': homodyne(),
         'PolyXP': poly_xp,
-        'NumberState': number_state
+        'NumberState': number_state,
+        'Identity': identity
     }
 
     _circuits = {}

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -91,7 +91,7 @@ class GaussianTests(BaseTest):
 
         dev = qml.device('strawberryfields.gaussian', wires=2)
         obs = set(dev._expectation_map.keys())
-        all_obs = {m[0] for m in inspect.getmembers(qml.expval, inspect.isclass)}
+        all_obs = set(qml.expval.__all__)
 
         for g in all_obs - obs:
             op = getattr(qml.expval, g)


### PR DESCRIPTION
**Description of the Change:**

PennyLane core now supports the `Identity` expectation value. This is convenient for the `strawberryfields.fock` device, as it provides information regarding the trace of the system. This PR implements support in the PennyLane-SF plugin.

**Benefits:**

* Can be used to keep track of the trace in the `strawberryfields.fock` device
* Simply returns 1 if used in the `strawberryfields.gaussian` device

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
