### PR TITLE
Update version number of plugin and device requires

### DIFF
--- a/pennylane_sf/_version.py
+++ b/pennylane_sf/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/pennylane_sf/simulator.py
+++ b/pennylane_sf/simulator.py
@@ -56,7 +56,7 @@ class StrawberryFieldsSimulator(Device):
         hbar (float): the convention chosen in the canonical commutation relation :math:`[x, p] = i \hbar`
     """
     name = 'Strawberry Fields Simulator PennyLane plugin'
-    pennylane_requires = '0.2.0'
+    pennylane_requires = '>=0.2.0'
     version = __version__
     author = 'Josh Izaac'
 


### PR DESCRIPTION
**Description of the Change:**

* Allows PennyLane-SF devices to be used with all newer version of PennyLane, not just version 0.2.0.

