### PR TITLE
Fix observable names

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Release 0.2.0-dev
+
+* Renamed the observables `MeanPhoton` to `NumberOperator`, `Homodyne` to `QuadOperator` and
+  `NumberState` to `FockStateProjector` to be compatible with the upcoming version of PennyLane (0.5.0).
+
 # Release 0.1.0
 
 Initial public release.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.2.0-dev
+# Release 0.5.0-dev
 
 * Renamed the observables `MeanPhoton` to `NumberOperator`, `Homodyne` to `QuadOperator` and
   `NumberState` to `FockStateProjector` to be compatible with the upcoming version of PennyLane (0.5.0).

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Renamed the observables `MeanPhoton` to `NumberOperator`, `Homodyne` to `QuadOperator` and
   `NumberState` to `FockStateProjector` to be compatible with the upcoming version of PennyLane (0.5.0).
+  [#19](https://github.com/XanaduAI/pennylane-sf/pull/19)
 
 # Release 0.1.0
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -83,7 +83,7 @@ Supported operations
 
 	* **Supported operations:** ``Beamsplitter``, ``ControlledAddition``, ``ControlledPhase``, ``Displacement``, ``Kerr``, ``CrossKerr``, ``QuadraticPhase``, ``Rotation``, ``Squeezing``, ``TwoModeSqueezing``, ``CubicPhase``, ``CatState``, ``CoherentState``, ``FockDensityMatrix``, ``DisplacedSqueezedState``, ``FockState``, ``FockStateVector``, ``SqueezedState``, ``ThermalState``, ``GaussianState``
 
-	* **Supported observables:** ``Identity``, ``NumberOperator``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
+	* **Supported observables:** ``Identity``, ``NumberOperator``, ``X``, ``P``, ``QuadOperator``, ``PolyXP``
 
 
 :class:`strawberryfields.gaussian <~StrawberryFieldsGaussian>`
@@ -92,4 +92,4 @@ Supported operations
 
 	* **Supported operations:** ``Beamsplitter``, ``ControlledAddition``, ``ControlledPhase``, ``Displacement``, ``QuadraticPhase``, ``Rotation``, ``Squeezing``, ``TwoModeSqueezing``, ``CoherentState``, ``DisplacedSqueezedState``, ``SqueezedState``, ``ThermalState``, ``GaussianState``
 
-	* **Supported observables:** ``Identity``, ``NumberOperator``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
+	* **Supported observables:** ``Identity``, ``NumberOperator``, ``X``, ``P``, ``QuadOperator``, ``PolyXP``

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -34,7 +34,7 @@ This function is then converted into a QNode which is placed on the :code:`straw
 >>> def quantum_function(x, theta):
 >>> 	qml.Displacement(x, 0, wires=0)
 >>> 	qml.Beamsplitter(theta, 0, wires=[0, 1])
->>> 	return qml.expval(qml.MeanPhoton(0))
+>>> 	return qml.expval(qml.NumberOperator(0))
 
 We can evaluate the QNode for arbitrary values of the circuit parameters:
 
@@ -83,7 +83,7 @@ Supported operations
 
 	* **Supported operations:** ``Beamsplitter``, ``ControlledAddition``, ``ControlledPhase``, ``Displacement``, ``Kerr``, ``CrossKerr``, ``QuadraticPhase``, ``Rotation``, ``Squeezing``, ``TwoModeSqueezing``, ``CubicPhase``, ``CatState``, ``CoherentState``, ``FockDensityMatrix``, ``DisplacedSqueezedState``, ``FockState``, ``FockStateVector``, ``SqueezedState``, ``ThermalState``, ``GaussianState``
 
-	* **Supported observables:** ``Identity``, ``MeanPhoton``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
+	* **Supported observables:** ``Identity``, ``NumberOperator``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
 
 
 :class:`strawberryfields.gaussian <~StrawberryFieldsGaussian>`
@@ -92,4 +92,4 @@ Supported operations
 
 	* **Supported operations:** ``Beamsplitter``, ``ControlledAddition``, ``ControlledPhase``, ``Displacement``, ``QuadraticPhase``, ``Rotation``, ``Squeezing``, ``TwoModeSqueezing``, ``CoherentState``, ``DisplacedSqueezedState``, ``SqueezedState``, ``ThermalState``, ``GaussianState``
 
-	* **Supported observables:** ``Identity``, ``MeanPhoton``, ``X``, ``P``, ``Homodyne``, ``PolyXP``
+	* **Supported observables:** ``Identity``, ``NumberOperator``, ``X``, ``P``, ``Homodyne``, ``PolyXP``

--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -79,7 +79,7 @@ def identity(state, wires, params):
 
 
 def mean_photon(state, wires, params):
-    """Computes the expectation value of the ``qml.MeanPhoton``
+    """Computes the expectation value of the ``qml.NumberOperator``
     observable in Strawberry Fields.
 
     Args:

--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -154,7 +154,7 @@ def number_state(state, wires, params):
 
 
 def homodyne(phi=None):
-    """Function factory that returns the ``qml.Homodyne`` expectation
+    """Function factory that returns the ``qml.QuadOperator`` expectation
     function for Strawberry Fields.
 
     ``homodyne(phi)`` returns a function

--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -95,7 +95,7 @@ def mean_photon(state, wires, params):
 
 
 def number_state(state, wires, params):
-    """Computes the expectation value of the ``qml.NumberState``
+    """Computes the expectation value of the ``qml.FockStateProjector``
     observable in Strawberry Fields.
 
     Args:

--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -25,7 +25,7 @@ to the corresponding state methods in Strawberry Fields.
 .. autosummary::
     identity
     mean_photon
-    number_state
+    fock_state
     homodyne
     poly_xp
 
@@ -94,7 +94,7 @@ def mean_photon(state, wires, params):
     return state.mean_photon(wires[0])
 
 
-def number_state(state, wires, params):
+def fock_state(state, wires, params):
     """Computes the expectation value of the ``qml.FockStateProjector``
     observable in Strawberry Fields.
 

--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -85,7 +85,7 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
     }
 
     _observable_map = {
-        'MeanPhoton': mean_photon,
+        'NumberOperator': mean_photon,
         'X': homodyne(0),
         'P': homodyne(np.pi/2),
         'Homodyne': homodyne(),

--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -90,7 +90,7 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
         'P': homodyne(np.pi/2),
         'QuadOperator': homodyne(),
         'PolyXP': poly_xp,
-        'NumberState': number_state,
+        'FockStateProjector': number_state,
         'Identity': identity
     }
 

--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -88,7 +88,7 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
         'NumberOperator': mean_photon,
         'X': homodyne(0),
         'P': homodyne(np.pi/2),
-        'Homodyne': homodyne(),
+        'QuadOperator': homodyne(),
         'PolyXP': poly_xp,
         'NumberState': number_state,
         'Identity': identity

--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -42,7 +42,7 @@ from strawberryfields.ops import (Catstate, Coherent, DensityMatrix, DisplacedSq
 from strawberryfields.ops import (BSgate, CKgate, CXgate, CZgate, Dgate,
                                   Kgate, Pgate, Rgate, S2gate, Sgate, Vgate)
 
-from .expectations import (identity, mean_photon, homodyne, number_state, poly_xp)
+from .expectations import (identity, mean_photon, homodyne, fock_state, poly_xp)
 from .simulator import StrawberryFieldsSimulator
 
 
@@ -90,7 +90,7 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
         'P': homodyne(np.pi/2),
         'QuadOperator': homodyne(),
         'PolyXP': poly_xp,
-        'FockStateProjector': number_state,
+        'FockStateProjector': fock_state,
         'Identity': identity
     }
 

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -76,7 +76,7 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
         'P': homodyne(np.pi/2),
         'QuadOperator': homodyne(),
         'PolyXP': poly_xp,
-        'NumberState': number_state,
+        'FockStateProjector': number_state,
         'Identity': identity
     }
 

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -74,7 +74,7 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
         'NumberOperator': mean_photon,
         'X': homodyne(0),
         'P': homodyne(np.pi/2),
-        'Homodyne': homodyne(),
+        'QuadOperator': homodyne(),
         'PolyXP': poly_xp,
         'NumberState': number_state,
         'Identity': identity

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -44,7 +44,7 @@ from strawberryfields.ops import (Coherent, DisplacedSqueezed,
 from strawberryfields.ops import (BSgate, CXgate, CZgate, Dgate,
                                   Pgate, Rgate, S2gate, Sgate)
 
-from .expectations import (identity, mean_photon, homodyne, number_state, poly_xp)
+from .expectations import (identity, mean_photon, homodyne, fock_state, poly_xp)
 from .simulator import StrawberryFieldsSimulator
 
 
@@ -76,7 +76,7 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
         'P': homodyne(np.pi/2),
         'QuadOperator': homodyne(),
         'PolyXP': poly_xp,
-        'FockStateProjector': number_state,
+        'FockStateProjector': fock_state,
         'Identity': identity
     }
 

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -71,7 +71,7 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
     }
 
     _observable_map = {
-        'MeanPhoton': mean_photon,
+        'NumberOperator': mean_photon,
         'X': homodyne(0),
         'P': homodyne(np.pi/2),
         'Homodyne': homodyne(),

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -86,7 +86,7 @@ class FockTests(BaseTest):
                 op(*args, wires=wires)
 
                 if issubclass(op, qml.operation.CV):
-                    return qml.expval(qml.MeanPhoton(0))
+                    return qml.expval(qml.NumberOperator(0))
                 else:
                     return qml.expval(qml.PauliZ(0))
 
@@ -130,7 +130,7 @@ class FockTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
-            return qml.expval(qml.MeanPhoton(0))
+            return qml.expval(qml.NumberOperator(0))
 
         self.assertAlmostEqual(circuit(1), 1, delta=self.tol)
 
@@ -144,7 +144,7 @@ class FockTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
-            return qml.expval(qml.MeanPhoton(0))
+            return qml.expval(qml.NumberOperator(0))
 
         x = 1
 
@@ -181,7 +181,7 @@ class FockTests(BaseTest):
             def circuit(*args):
                 qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
                 op(*args, wires=wires)
-                return qml.expval(qml.MeanPhoton(0)), qml.expval(qml.MeanPhoton(1))
+                return qml.expval(qml.NumberOperator(0)), qml.expval(qml.NumberOperator(1))
 
             # compare to reference SF engine
             def SF_reference(*args):
@@ -396,7 +396,7 @@ class TestVariance:
         def circuit(n, a):
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
-            return qml.var(qml.MeanPhoton(0))
+            return qml.var(qml.NumberOperator(0))
 
         n = 0.12
         a = 0.105

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -295,7 +295,7 @@ class FockTests(BaseTest):
         # test X expectation
         self.assertAlmostEqual(circuit(a), nbar+np.abs(a)**2)
 
-    def test_number_state(self):
+    def test_fock_state(self):
         """Test that FockStateProjector works as expected"""
         self.logTestName()
 

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -258,7 +258,7 @@ class FockTests(BaseTest):
             if op.num_params == 0:
                 self.assertAllEqual(circuit(), SF_reference())
             elif op.num_params == 1:
-                if g == 'NumberState':
+                if g == 'FockStateProjector':
                     p = np.array([1])
                 else:
                     p = a_array if op.par_domain == 'A' else a
@@ -296,7 +296,7 @@ class FockTests(BaseTest):
         self.assertAlmostEqual(circuit(a), nbar+np.abs(a)**2)
 
     def test_number_state(self):
-        """Test that NumberState works as expected"""
+        """Test that FockStateProjector works as expected"""
         self.logTestName()
 
         cutoff_dim = 12
@@ -310,7 +310,7 @@ class FockTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
-            return qml.expval(qml.NumberState(np.array([2]), wires=0))
+            return qml.expval(qml.FockStateProjector(np.array([2]), wires=0))
 
         expected = np.abs(np.exp(-np.abs(a)**2/2)*a**2/np.sqrt(2))**2
         self.assertAlmostEqual(circuit(a), expected)
@@ -319,7 +319,7 @@ class FockTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Squeezing(x, 0, wires=0)
-            return qml.expval(qml.NumberState(np.array([2, 0]), wires=[0, 1]))
+            return qml.expval(qml.FockStateProjector(np.array([2, 0]), wires=[0, 1]))
 
         expected = np.abs(np.sqrt(2)/(2)*(-np.tanh(r))/np.sqrt(np.cosh(r)))**2
         self.assertAlmostEqual(circuit(r), expected)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -272,7 +272,7 @@ class GaussianTests(BaseTest):
         # test X expectation
         self.assertAlmostEqual(circuit(a), nbar+np.abs(a)**2)
 
-    def test_number_state(self):
+    def test_fock_state(self):
         """Test that FockStateProjector works as expected"""
         self.logTestName()
 

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -120,7 +120,7 @@ class GaussianTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
-            return qml.expval(qml.MeanPhoton(0))
+            return qml.expval(qml.NumberOperator(0))
 
         self.assertAlmostEqual(circuit(1), 1, delta=self.tol)
 
@@ -134,7 +134,7 @@ class GaussianTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
-            return qml.expval(qml.MeanPhoton(0))
+            return qml.expval(qml.NumberOperator(0))
 
         x = 1
 
@@ -170,7 +170,7 @@ class GaussianTests(BaseTest):
             def circuit(*x):
                 qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
                 op(*x, wires=wires)
-                return qml.expval(qml.MeanPhoton(0)), qml.expval(qml.MeanPhoton(1))
+                return qml.expval(qml.NumberOperator(0)), qml.expval(qml.NumberOperator(1))
 
             # compare to reference SF engine
             def SF_reference(*x):
@@ -339,7 +339,7 @@ class TestVariance:
         def circuit(n, a):
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
-            return qml.var(qml.MeanPhoton(0))
+            return qml.var(qml.NumberOperator(0))
 
         n = 0.12
         a = 0.765

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -236,7 +236,7 @@ class GaussianTests(BaseTest):
             if op.num_params == 0:
                 self.assertAllEqual(circuit(), SF_reference())
             elif op.num_params == 1:
-                if g == 'NumberState':
+                if g == 'FockStateProjector':
                     p = np.array([1])
                 else:
                     p = a_array if op.par_domain == 'A' else a
@@ -273,7 +273,7 @@ class GaussianTests(BaseTest):
         self.assertAlmostEqual(circuit(a), nbar+np.abs(a)**2)
 
     def test_number_state(self):
-        """Test that NumberState works as expected"""
+        """Test that FockStateProjector works as expected"""
         self.logTestName()
 
         a = 0.54321
@@ -286,7 +286,7 @@ class GaussianTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
-            return qml.expval(qml.NumberState(np.array([2]), wires=0))
+            return qml.expval(qml.FockStateProjector(np.array([2]), wires=0))
 
         expected = np.abs(np.exp(-np.abs(a)**2/2)*a**2/np.sqrt(2))**2
         self.assertAlmostEqual(circuit(a), expected)
@@ -295,7 +295,7 @@ class GaussianTests(BaseTest):
         @qml.qnode(dev)
         def circuit(x):
             qml.Squeezing(x, 0, wires=0)
-            return qml.expval(qml.NumberState(np.array([2, 0]), wires=[0, 1]))
+            return qml.expval(qml.FockStateProjector(np.array([2, 0]), wires=[0, 1]))
 
         expected = np.abs(np.sqrt(2)/(2)*(-np.tanh(r))/np.sqrt(np.cosh(r)))**2
         self.assertAlmostEqual(circuit(r), expected)


### PR DESCRIPTION
**Description of the Change:**
Replace the names of observables to be in tune with PennyLane.

**Benefits:**
Restores compatibility with recent versions of PennyLane.

**Possible Drawbacks:**

**Related GitHub Issues:**
#18