### PR TITLE
Replace calls to device.supported

### DIFF
--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -169,7 +169,7 @@ class FockTests(BaseTest):
         gates = list(dev._operation_map.items())
         for g, sfop in gates:
             log.info('\tTesting gate {}...'.format(g))
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_operation(g))
 
             op = getattr(qml.ops, g)
             if op.num_wires == 0:
@@ -229,7 +229,7 @@ class FockTests(BaseTest):
         expectations = list(dev._observable_map.items())
         for g, sfop in expectations:
             log.info('\tTesting expectation {}...'.format(g))
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_observable(g))
 
             op = getattr(qml.ops, g)
             if op.num_wires == 0:

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -158,7 +158,7 @@ class GaussianTests(BaseTest):
         gates = list(dev._operation_map.items())
         for g, sfop in gates:
             log.info('\tTesting gate {}...'.format(g))
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_operation(g))
 
             op = getattr(qml.ops, g)
             if op.num_wires == 0:
@@ -207,7 +207,7 @@ class GaussianTests(BaseTest):
         expectations = list(dev._observable_map.items())
         for g, sfop in expectations:
             log.info('\tTesting expectation {}...'.format(g))
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_observable(g))
 
             op = getattr(qml.ops, g)
             if op.num_wires == 0:


### PR DESCRIPTION
Replace calls to `device.supported` with the appropriate `device.supports_observable` and `device.supports_operation` introduced in the latest version of pennylane.
