### PR TITLE
Adds analytic argument, removes shots=0

### DIFF
--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -51,10 +51,12 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
 
     Args:
         wires (int): the number of modes to initialize the device in
-        shots (int): Number of circuit evaluations/random samples
-            used to estimate expectation values of observables.
-            For simulator devices, 0 means the exact EV is returned.
+        analytic (bool): indicates if the device should calculate expectations
+            and variances analytically
         cutoff_dim (int): Fock-space truncation dimension
+        shots (int): Number of circuit evaluations/random samples used
+            to estimate expectation values of observables. If ``analytic=True``,
+            this setting is ignored.
         hbar (float): the convention chosen in the canonical commutation
             relation :math:`[x, p] = i \hbar`
     """
@@ -96,8 +98,8 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
 
     _circuits = {}
 
-    def __init__(self, wires, *, cutoff_dim, shots=0, hbar=2):
-        super().__init__(wires, shots=shots, hbar=hbar)
+    def __init__(self, wires, *, analytic=True, cutoff_dim, shots=1000, hbar=2):
+        super().__init__(wires, analytic=analytic, shots=shots, hbar=hbar)
         self.cutoff = cutoff_dim
 
     def pre_measure(self):

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -49,7 +49,17 @@ from .simulator import StrawberryFieldsSimulator
 
 
 class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
-    """StrawberryFields Gaussian device for PennyLane.
+    r"""StrawberryFields Gaussian device for PennyLane.
+
+    Args:
+        wires (int): the number of modes to initialize the device in
+        analytic (bool): indicates if the device should calculate expectations
+            and variances analytically
+        shots (int): Number of circuit evaluations/random samples used
+            to estimate expectation values of observables. If ``analytic=True``,
+            this setting is ignored.
+        hbar (float): the convention chosen in the canonical commutation
+            relation :math:`[x, p] = i \hbar`
     """
     name = 'Strawberry Fields Gaussian PennyLane plugin'
     short_name = 'strawberryfields.gaussian'

--- a/pennylane_sf/simulator.py
+++ b/pennylane_sf/simulator.py
@@ -50,10 +50,13 @@ class StrawberryFieldsSimulator(Device):
 
     Args:
         wires (int): the number of modes to initialize the device in
+        analytic (bool): indicates if the device should calculate expectations
+            and variances analytically
         shots (int): Number of circuit evaluations/random samples used
-            to estimate expectation values of observables.
-            For simulator devices, 0 means the exact EV is returned.
-        hbar (float): the convention chosen in the canonical commutation relation :math:`[x, p] = i \hbar`
+            to estimate expectation values of observables. If ``analytic=True``,
+            this setting is ignored.
+        hbar (float): the convention chosen in the canonical commutation
+            relation :math:`[x, p] = i \hbar`
     """
     name = 'Strawberry Fields Simulator PennyLane plugin'
     pennylane_requires = '>=0.5.0'
@@ -64,7 +67,7 @@ class StrawberryFieldsSimulator(Device):
     _operation_map = {}
     _observable_map = {}
 
-    def __init__(self, wires, *, shots=0, hbar=2):
+    def __init__(self, wires, *, analytic=True, shots=1000, hbar=2):
         super().__init__(wires, shots)
         self.hbar = hbar
         self.prog = None
@@ -72,6 +75,7 @@ class StrawberryFieldsSimulator(Device):
         self.q = None
         self.state = None
         self.samples = None
+        self.analytic = analytic
 
     def execution_context(self):
         """Initialize the engine"""
@@ -118,7 +122,7 @@ class StrawberryFieldsSimulator(Device):
         """
         ex, var = self._observable_map[observable](self.state, wires, par)
 
-        if self.shots != 0:
+        if not self.analytic:
             # estimate the expectation value
             # use central limit theorem, sample normal distribution once, only ok
             # if shots is large (see https://en.wikipedia.org/wiki/Berry%E2%80%93Esseen_theorem)

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -52,7 +52,7 @@ class FockTests(BaseTest):
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.cutoff, 5)
         self.assertEqual(dev.hbar, 2)
-        self.assertEqual(dev.shots, 0)
+        self.assertEqual(dev.shots, 1000)
         self.assertEqual(dev.short_name, 'strawberryfields.fock')
 
     def test_fock_args(self):
@@ -75,7 +75,7 @@ class FockTests(BaseTest):
         for g in all_gates - gates:
             op = getattr(qml.ops, g)
 
-            if op.num_wires == 0:
+            if op.num_wires <= 0:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))
@@ -83,6 +83,7 @@ class FockTests(BaseTest):
             @qml.qnode(dev)
             def circuit(*args):
                 args = prep_par(args, op)
+                print(wires)
                 op(*args, wires=wires)
 
                 if issubclass(op, qml.operation.CV):
@@ -106,7 +107,7 @@ class FockTests(BaseTest):
         for g in all_obs - obs:
             op = getattr(qml.ops, g)
 
-            if op.num_wires == 0:
+            if op.num_wires <= 0:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -75,7 +75,7 @@ class FockTests(BaseTest):
         for g in all_gates - gates:
             op = getattr(qml.ops, g)
 
-            if op.num_wires <= 0:
+            if op.num_wires is qml.operation.Wires.Any or qml.operation.Wires.All:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))
@@ -83,7 +83,6 @@ class FockTests(BaseTest):
             @qml.qnode(dev)
             def circuit(*args):
                 args = prep_par(args, op)
-                print(wires)
                 op(*args, wires=wires)
 
                 if issubclass(op, qml.operation.CV):
@@ -107,7 +106,7 @@ class FockTests(BaseTest):
         for g in all_obs - obs:
             op = getattr(qml.ops, g)
 
-            if op.num_wires <= 0:
+            if op.num_wires is qml.operation.Wires.Any or qml.operation.Wires.All:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -44,7 +44,7 @@ class GaussianTests(BaseTest):
         dev = qml.device('strawberryfields.gaussian', wires=2)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.hbar, 2)
-        self.assertEqual(dev.shots, 0)
+        self.assertEqual(dev.shots, 1000)
         self.assertEqual(dev.short_name, 'strawberryfields.gaussian')
 
     def test_gaussian_args(self):


### PR DESCRIPTION
**Description of the Change:**

* Adds `analytic=True` as a default argument
* Changes `shots=0` to `shots=1000` by default

**Benefits:**

Brings the plugin inline with https://github.com/XanaduAI/pennylane/pull/317

**Possible Drawbacks:**

None. Note that the SF plugin currently does not support sampling, so the ``shots`` argument only affects expectation/variance estimation.

**Related GitHub Issues:** #23 
