### PR TITLE
Add cubic phase gate and interferometer, version bump

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,18 +1,17 @@
-# Release 0.6.0-dev
-
-### New features since last release
-
-### Breaking changes
-
-### Improvements
-
-### Documentation
+# Release 0.6.0
 
 ### Bug fixes
+
+* Two missing gates have been added. Cubic phase gate has been added
+  to the `strawberryfields.fock` device, and the Inteferometer has
+  been added to both `strawberryfields.fock` and `strawberryfields.gaussian`.
+  [#19](https://github.com/XanaduAI/pennylane-sf/pull/19)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac
 
 ---
 
@@ -21,6 +20,12 @@ This release contains contributions from (in alphabetical order):
 * Renamed the observables `MeanPhoton` to `NumberOperator`, `Homodyne` to `QuadOperator` and
   `NumberState` to `FockStateProjector` to be compatible with the upcoming version of PennyLane (0.5.0).
   [#19](https://github.com/XanaduAI/pennylane-sf/pull/19)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+Josh Izaac
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Two missing gates have been added. Cubic phase gate has been added
   to the `strawberryfields.fock` device, and the Inteferometer has
   been added to both `strawberryfields.fock` and `strawberryfields.gaussian`.
-  [#19](https://github.com/XanaduAI/pennylane-sf/pull/19)
+  [#25](https://github.com/XanaduAI/pennylane-sf/pull/25)
 
 ### Contributors
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON3 := $(shell which python3 2>/dev/null)
 
 PYTHON := python3
 COVERAGE := --cov=pennylane_sf --cov-report term-missing --cov-report=html:coverage_html_report
-TESTRUNNER := -m pytest tests
+TESTRUNNER := -m pytest tests --tb=short
 
 .PHONY: help
 help:

--- a/pennylane_sf/_version.py
+++ b/pennylane_sf/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.6.0-dev'
+__version__ = '0.6.0'

--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -40,7 +40,7 @@ from strawberryfields.ops import (Catstate, Coherent, DensityMatrix, DisplacedSq
                                   Fock, Ket, Squeezed, Thermal, Gaussian)
 # import gates
 from strawberryfields.ops import (BSgate, CKgate, CXgate, CZgate, Dgate,
-                                  Kgate, Pgate, Rgate, S2gate, Sgate, Vgate)
+                                  Kgate, Pgate, Rgate, S2gate, Sgate, Vgate, Interferometer)
 
 from .expectations import (identity, mean_photon, homodyne, fock_state, poly_xp)
 from .simulator import StrawberryFieldsSimulator
@@ -83,7 +83,8 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
         'Rotation': Rgate,
         'TwoModeSqueezing': S2gate,
         'Squeezing': Sgate,
-        'CubicPhase': Vgate
+        'CubicPhase': Vgate,
+        'Interferometer': Interferometer
     }
 
     _observable_map = {

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -42,7 +42,7 @@ from strawberryfields.ops import (Coherent, DisplacedSqueezed,
                                   Squeezed, Thermal, Gaussian)
 # import gates
 from strawberryfields.ops import (BSgate, CXgate, CZgate, Dgate,
-                                  Pgate, Rgate, S2gate, Sgate)
+                                  Pgate, Rgate, S2gate, Sgate, Interferometer)
 
 from .expectations import (identity, mean_photon, homodyne, fock_state, poly_xp)
 from .simulator import StrawberryFieldsSimulator
@@ -77,7 +77,8 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
         'QuadraticPhase': Pgate,
         'Rotation': Rgate,
         'TwoModeSqueezing': S2gate,
-        'Squeezing': Sgate
+        'Squeezing': Sgate,
+        'Interferometer': Interferometer
     }
 
     _observable_map = {

--- a/pennylane_sf/simulator.py
+++ b/pennylane_sf/simulator.py
@@ -59,7 +59,7 @@ class StrawberryFieldsSimulator(Device):
             relation :math:`[x, p] = i \hbar`
     """
     name = 'Strawberry Fields Simulator PennyLane plugin'
-    pennylane_requires = '>=0.5.0'
+    pennylane_requires = '>=0.6.0'
     version = __version__
     author = 'Josh Izaac'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 strawberryfields>=0.11
-pennylane>=0.5
+pennylane>=0.6

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("pennylane_sf/_version.py") as f:
 
 requirements = [
     "strawberryfields>=0.11",
-    "pennylane>=0.5"
+    "pennylane>=0.6"
 ]
 
 info = {

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -34,6 +34,14 @@ psi = np.array([ 0.08820314+0.14909648j,  0.32826940+0.32956027j,
         0.21021125+0.30082734j,  0.23443833+0.19584968j])
 
 
+U = np.array(
+    [
+        [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
+        [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
+    ]
+)
+
+
 def prep_par(par, op):
     "Convert par into a list of parameters that op expects."
     if op.par_domain == 'A':
@@ -172,7 +180,9 @@ class FockTests(BaseTest):
             self.assertTrue(dev.supports_operation(g))
 
             op = getattr(qml.ops, g)
-            if op.num_wires <= 0:
+            if g == "Interferometer":
+                wires = [0, 1]
+            elif op.num_wires <= 0:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))
@@ -180,6 +190,7 @@ class FockTests(BaseTest):
             @qml.qnode(dev)
             def circuit(*args):
                 qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
+                print(args, wires)
                 op(*args, wires=wires)
                 return qml.expval(qml.NumberOperator(0)), qml.expval(qml.NumberOperator(1))
 
@@ -199,6 +210,8 @@ class FockTests(BaseTest):
                 r = np.array([0, 0])
                 V = np.array([[0.5, 0], [0, 2]])
                 self.assertAllEqual(circuit(V, r), SF_reference(V, r))
+            elif g == 'Interferometer':
+                self.assertAllEqual(circuit(U), SF_reference(U))
             elif g == 'FockDensityMatrix':
                 dm = np.outer(psi, psi.conj())
                 self.assertAllEqual(circuit(dm), SF_reference(dm))

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -182,7 +182,7 @@ class FockTests(BaseTest):
             op = getattr(qml.ops, g)
             if g == "Interferometer":
                 wires = [0, 1]
-            elif op.num_wires <= 0:
+            elif op.num_wires is (qml.operation.Wires.Any or qml.operation.Wires.All):
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))
@@ -190,7 +190,6 @@ class FockTests(BaseTest):
             @qml.qnode(dev)
             def circuit(*args):
                 qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
-                print(args, wires)
                 op(*args, wires=wires)
                 return qml.expval(qml.NumberOperator(0)), qml.expval(qml.NumberOperator(1))
 

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -27,6 +27,14 @@ from pennylane import numpy as np
 from defaults import BaseTest
 
 
+U = np.array(
+    [
+        [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
+        [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
+    ]
+)
+
+
 def prep_par(par, op):
     "Convert par into a list of parameters that op expects."
     if op.par_domain == 'A':
@@ -161,7 +169,9 @@ class GaussianTests(BaseTest):
             self.assertTrue(dev.supports_operation(g))
 
             op = getattr(qml.ops, g)
-            if op.num_wires <= 0:
+            if g == "Interferometer":
+                wires = [0, 1]
+            elif op.num_wires <= 0:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))
@@ -188,6 +198,8 @@ class GaussianTests(BaseTest):
                 r = np.array([0, 0])
                 V = np.array([[0.5, 0], [0, 2]])
                 self.assertAllEqual(circuit(V, r), SF_reference(V, r))
+            elif g == 'Interferometer':
+                self.assertAllEqual(circuit(U), SF_reference(U))
             elif g == "DisplacedSqueezedState":
                 self.assertAllEqual(circuit(a, b, c, d),
                                     SF_reference(a*np.exp(1j*b), c, d))

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -171,7 +171,7 @@ class GaussianTests(BaseTest):
             op = getattr(qml.ops, g)
             if g == "Interferometer":
                 wires = [0, 1]
-            elif op.num_wires <= 0:
+            elif op.num_wires is (qml.operation.Wires.Any or qml.operation.Wires.All):
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))


### PR DESCRIPTION
**Description of the Change:**

* Two missing gates have been added. Cubic phase gate has been added
  to the `strawberryfields.fock` device, and the Inteferometer has
  been added to both `strawberryfields.fock` and `strawberryfields.gaussian`.

* Updates the version number and changelog, getting ready for a new release.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
