### PR TITLE
Add model key to capabilities dictionary

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Bug fixes
 
+* Adds the `"model"` key to the `Device._capabilities` dictionary,
+  to properly register the device as a CV device. Fixes
+  [#27](https://github.com/XanaduAI/pennylane-sf/issues/27)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_sf/simulator.py
+++ b/pennylane_sf/simulator.py
@@ -66,6 +66,7 @@ class StrawberryFieldsSimulator(Device):
     short_name = 'strawberryfields'
     _operation_map = {}
     _observable_map = {}
+    _capabilities = {"model": "cv"}
 
     def __init__(self, wires, *, analytic=True, shots=1000, hbar=2):
         super().__init__(wires, shots)


### PR DESCRIPTION
**Description of the Change:** PennyLane master now requires all devices to specify their model in the capabilities dictionary.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** Fixes #27 
