### PR TITLE
Incrementing the version number to 0.9.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,18 +1,20 @@
-# Release 0.9.0-dev
-
-### New features since last release
-
-### Breaking changes
+# Release 0.9.0
 
 ### Improvements
 
+* Refactored the test suite.
+  [#33](https://github.com/XanaduAI/pennylane-sf/pull/33)
+
 ### Documentation
 
-### Bug fixes
+* Major redesign of the documentation, making it easier to navigate.
+  [#32](https://github.com/XanaduAI/pennylane-sf/pull/32)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac, Maria Schuld, Antal Száva
 
 ---
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 python:
   - 3.6
   - 3.7
+  - 3.8
 env:
   - LOGGING=info
 install:

--- a/README.rst
+++ b/README.rst
@@ -77,12 +77,12 @@ Dependencies
 
 PennyLane-SF requires the following libraries be installed:
 
-* `Python <http://python.org/>`_ >=3.5
+* `Python <http://python.org/>`_ >=3.6
 
 as well as the following Python packages:
 
-* `PennyLane <http://pennylane.readthedocs.io/>`_ >=0.4
-* `StrawberryFields <https://strawberryfields.readthedocs.io/>`_ >=0.11
+* `PennyLane <http://pennylane.readthedocs.io/>`_ >=0.7
+* `StrawberryFields <https://strawberryfields.readthedocs.io/>`_ >=0.11.2
 
 
 If you currently do not have Python 3 installed,

--- a/pennylane_sf/_version.py
+++ b/pennylane_sf/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.9.0-dev'
+__version__ = '0.9.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-strawberryfields>=0.11
+strawberryfields>=0.14
 pennylane>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-strawberryfields>=0.14
+strawberryfields>=0.11
 pennylane>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-strawberryfields>=0.11
+strawberryfields>=0.11.2
 pennylane>=0.7

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("pennylane_sf/_version.py") as f:
 
 
 requirements = [
-    "strawberryfields>=0.11",
+    "strawberryfields>=0.14",
     "pennylane>=0.7"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("pennylane_sf/_version.py") as f:
 
 
 requirements = [
-    "strawberryfields>=0.14",
+    "strawberryfields>=0.11.2",
     "pennylane>=0.7"
 ]
 
@@ -65,8 +65,9 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3 :: Only',
     "Topic :: Scientific/Engineering :: Physics"
 ]

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -380,24 +380,6 @@ class TestGates:
         sf_res = SF_gate_reference(sf_operation, cutoff_dim, wires, a * np.exp(1j * b), c)
         assert np.allclose(res, sf_res, atol=tol, rtol=0)
 
-    def test_tensorn_not_supported(self):
-        """Test error is raised with the unsupported TensorN observable"""
-        dev = qml.device("strawberryfields.fock", wires=2, cutoff_dim=2)
-
-        observable = qml.TensorN
-        wires = [0, 1]
-
-        @qml.qnode(dev)
-        def circuit():
-            return qml.expval(observable(wires=wires))
-
-        with pytest.raises(
-            qml.DeviceError,
-            match="Observable TensorN not supported " "on device strawberryfields.fock",
-        ):
-            circuit()
-
-
 class TestExpectation:
     """Test that all supported expectations work as expected when compared to
     the Strawberry Fields results"""

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -404,24 +404,6 @@ class TestUnsupported:
         ):
             circuit()
 
-    def test_tensorn_not_supported(self):
-        """Test error is raised with the unsupported TensorN observable"""
-        dev = qml.device("strawberryfields.gaussian", wires=2)
-
-        observable = qml.TensorN
-        wires = [0, 1]
-
-        @qml.qnode(dev)
-        def circuit():
-            return qml.expval(observable(wires=wires))
-
-        with pytest.raises(
-            qml.DeviceError,
-            match="Observable TensorN not supported " "on device strawberryfields.gaussian",
-        ):
-            circuit()
-
-
 class TestExpectation:
     """Test that all supported expectations work as expected when compared to
     the Strawberry Fields results"""


### PR DESCRIPTION
**Description of the Change:**
* Added changelog entries, bumped version
* Updated device version number
* Added Python 3.8 check to Travis
* Pinned to `strawberryfields>=11.2` due to an error with `Interferometer` from updated by [this SF commit](https://github.com/XanaduAI/strawberryfields/commit/a6f46152c98ce3bec619d6f62807a7fd88d7cb99#diff-16761d4d8cb28015d5aa4f9ad4100a86) (Jul 24, 2019). This change came after [SF release 0.11](https://github.com/XanaduAI/strawberryfields/releases/tag/v0.11.0), (Jul 10, 2019)
* Removed the PL-v0.9 specific `TensorN` tests so that the PennyLane requirement does not need to be increased