### PR TITLE
Check tests against PennyLane master and SF release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 install:
   - pip install pip --upgrade
   - pip install -e git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
-  - pip install -e git+https://github.com/XanaduAI/strawberryfields.git#egg=strawberryfields
+  # - pip install -e git+https://github.com/XanaduAI/strawberryfields.git#egg=strawberryfields
   - pip install -r requirements.txt
   - pip install pytest pytest-cov wheel codecov --upgrade
   - python3 setup.py bdist_wheel


### PR DESCRIPTION
This PR is branched off the last release of this plugin (git tag `v0.9.0`), and runs the continuous integration tests against:

* PennyLane master
* Strawberry Fields current release.