### PR TITLE
Added support for qml.probs to the simulator devices.

### DIFF
--- a/doc/devices/fock.rst
+++ b/doc/devices/fock.rst
@@ -68,7 +68,7 @@ Device options
 The Strawberry Fields Fock device accepts additional arguments beyond the PennyLane default device arguments.
 
 ``cutoff_dim``
-	the Fock basis truncation to be applied when executing quantum functions (``strawberryfields.fock`` only)
+	the Fock basis truncation when applying quantum operations
 
 ``hbar=2``
 	The convention chosen in the canonical commutation relation :math:`[x, p] = i \hbar`.
@@ -134,6 +134,7 @@ provided by PennyLane, including both Gaussian and non-Gaussian operations.
 
     ~pennylane.Identity
     ~pennylane.NumberOperator
+    ~pennylane.TensorN
     ~pennylane.X
     ~pennylane.P
     ~pennylane.QuadOperator

--- a/doc/devices/gaussian.rst
+++ b/doc/devices/gaussian.rst
@@ -58,6 +58,9 @@ The Strawberry Fields Gaussian device accepts additional arguments beyond the Pe
 	The convention chosen in the canonical commutation relation :math:`[x, p] = i \hbar`.
 	Default value is :math:`\hbar=2`.
 
+``cutoff_dim``
+    the Fock basis truncation to be applied when computing quantities in the Fock basis (such as probabilities)
+
 ``shots=0``
 	The number of circuit evaluations/random samples used to estimate expectation values of observables.
 	The default value of 0 means that the exact expectation value is returned.
@@ -110,6 +113,7 @@ observables provided by PennyLane.
 
     ~pennylane.Identity
     ~pennylane.NumberOperator
+    ~pennylane.TensorN
     ~pennylane.X
     ~pennylane.P
     ~pennylane.QuadOperator

--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -107,7 +107,7 @@ def number_expectation(state, wires, params):
             variance
     """
     # pylint: disable=unused-argument
-    return state.number_expectation(wires), None
+    return state.number_expectation(wires)
 
 
 def fock_state(state, wires, params):

--- a/pennylane_sf/gaussian.py
+++ b/pennylane_sf/gaussian.py
@@ -55,6 +55,7 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
         wires (int): the number of modes to initialize the device in
         analytic (bool): indicates if the device should calculate expectations
             and variances analytically
+        cutoff_dim (int): Fock-space truncation dimension
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables. If ``analytic=True``,
             this setting is ignored.
@@ -93,6 +94,10 @@ class StrawberryFieldsGaussian(StrawberryFieldsSimulator):
     }
 
     _circuits = {}
+
+    def __init__(self, wires, *, analytic=True, cutoff_dim=10, shots=1000, hbar=2):
+        super().__init__(wires, analytic=analytic, shots=shots, hbar=hbar)
+        self.cutoff = cutoff_dim
 
     def pre_measure(self):
         self.eng = sf.Engine("gaussian")

--- a/pennylane_sf/simulator.py
+++ b/pennylane_sf/simulator.py
@@ -146,9 +146,6 @@ class StrawberryFieldsSimulator(Device):
         """
         _, var = self._observable_map[observable](self.state, wires, par)
 
-        if var is None:
-            raise ValueError(f"{observable} does not support variances.")
-
         return var
 
     def reset(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/XanaduAI/strawberryfields.git
 pennylane>=0.7
+tensorflow==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-strawberryfields>=0.11.2
+git+https://github.com/XanaduAI/strawberryfields.git
 pennylane>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/XanaduAI/strawberryfields.git
-git+https://github.com/XanaduAI/pennylane.git@probs_cv_cutoff
+git+https://github.com/XanaduAI/pennylane.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 git+https://github.com/XanaduAI/strawberryfields.git
 pennylane>=0.7
-tensorflow==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/XanaduAI/strawberryfields.git
-pennylane>=0.7
+git+https://github.com/XanaduAI/pennylane.git@probs_cv_cutoff

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -720,6 +720,38 @@ class TestProbability:
         expected_gradient = 0
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
+    def test_finite_diff_coherent_two_wires(self, tol):
+        """Test that the jacobian of the probability for a coherent states is
+        approximated well with finite differences"""
+        cutoff = 4
+
+        dev = qml.device("strawberryfields.fock", wires=2, cutoff_dim=cutoff)
+
+        @qml.qnode(dev)
+        def circuit(a, phi):
+            qml.Displacement(a, phi, wires=0)
+            qml.Displacement(a, phi, wires=1)
+            return qml.probs(wires=[0, 1])
+
+        a = 0.4
+        phi = -0.12
+
+        c = np.arange(cutoff)
+        d = np.arange(cutoff)
+        n0, n1 = np.meshgrid(c, d)
+        n0 = n0.flatten()
+        n1 = n1.flatten()
+
+        # differentiate with respect to parameter a
+        res_F = circuit.jacobian([a, phi], wrt={0}, method="F").flat
+        expected_gradient = 2 * (a **(-1 + 2*n0 + 2*n1)) * np.exp(-2*a ** 2) * (-2*a ** 2 + n0 + n1) / (fac(n0) * fac(n1))
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+
+        # differentiate with respect to parameter phi
+        res_F = circuit.jacobian([a, phi], wrt={1}, method="F").flat
+        expected_gradient = 0
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to
         calculations for the NumberOperator"""

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -429,8 +429,9 @@ class TestExpectation:
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             return qml.expval(op(wires=wires))
 
+        expval = circuit()
         assert np.allclose(
-            circuit(), SF_expectation_reference(sf_expectation, cutoff_dim, wires), atol=tol, rtol=0
+            expval, SF_expectation_reference(sf_expectation, cutoff_dim, wires), atol=tol, rtol=0
         )
 
     @pytest.mark.parametrize("gate_name,op", [("X", qml.X), ("P", qml.P)])
@@ -760,24 +761,3 @@ class TestProbability:
         gradF = circuit.jacobian([n, a], method="F")
         expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
         assert np.allclose(gradF, expected, atol=tol, rtol=0)
-
-    def test_tensor_number_operator_raises(self, tol):
-        """Test that the variance of the TensorN observable
-        is not supported"""
-        cutoff_dim = 10
-
-        dev = qml.device("strawberryfields.fock", wires=2, cutoff_dim=cutoff_dim)
-
-        gate_name = "TensorN"
-        assert dev.supports_observable(gate_name)
-
-        op = qml.TensorN
-        sf_expectation = dev._observable_map[gate_name]
-        wires = [0, 1]
-
-        @qml.qnode(dev)
-        def circuit():
-            return qml.var(op(wires=wires))
-
-        with pytest.raises(ValueError, match="TensorN does not support variances."):
-            circuit()

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -721,6 +721,39 @@ class TestProbability:
         expected_gradient = 0
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
+    def test_finite_diff_squeezed(self, tol):
+        """Test that the jacobian of the probability for a squeezed states is
+        approximated well with finite differences"""
+        cutoff = 5
+
+        dev = qml.device("strawberryfields.fock", wires=1, cutoff_dim=cutoff)
+
+        @qml.qnode(dev)
+        def circuit(r, phi):
+            qml.Squeezing(r, phi, wires=0)
+            return qml.probs(wires=[0])
+
+        r = 0.4
+        phi = -0.12
+
+        n = np.arange(cutoff)
+
+        # differentiate with respect to parameter r
+        res_F = circuit.jacobian([r, phi], wrt={0}, method="F").flatten()
+        assert res_F.shape == (cutoff,)
+
+        expected_gradient = (
+            np.abs(np.tanh(r)) ** n * (1 + 2 * n - np.cosh(2 * r)) * fac(n)
+            / (2 ** (n + 1) * np.cosh(r) **2 * np.sinh(r) * fac(n / 2) ** 2)
+        )
+        expected_gradient[n % 2 != 0] = 0
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+
+        # differentiate with respect to parameter phi
+        res_F = circuit.jacobian([r, phi], wrt={1}, method="F").flat
+        expected_gradient = 0
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+
     def test_finite_diff_coherent_two_wires(self, tol):
         """Test that the jacobian of the probability for a coherent states on
         two wires is approximated well with finite differences"""
@@ -752,43 +785,6 @@ class TestProbability:
         res_F = circuit.jacobian([a, phi], wrt={1}, method="F").flat
         expected_gradient = 0
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
-
-    def test_finite_diff_squeezed(self, tol):
-        """Test that the jacobian of the probability for a squeezed state is
-        approximated well with finite differences"""
-        cutoff = 10
-
-        dev = qml.device("strawberryfields.fock", wires=1, cutoff_dim=cutoff)
-
-        @qml.qnode(dev)
-        def circuit(a, phi):
-            qml.Squeezing(a, phi, wires=0)
-            return qml.probs(wires=[0])
-
-        r = 0.4
-        phi = -0.12
-
-        n = np.arange(cutoff, dtype=float)
-
-        hermite_coeffs = np.array([1, 0, -2, 0, 12, 0, -120, 0, 1680, 0])
-
-        def sech(z):
-            return 1 / np.cosh(z)
-
-        def csch(z):
-            return 1 / np.sinh(z)
-
-        expected_gradient = hermite_coeffs **2 *(2**(-1 - n)*np.abs(np.tanh(r))**n*(1 + 2*n - np.cosh(2*r))*csch(r)*sech(r)**2)/fac(n)
-
-        # differentiate with respect to parameter r
-        res_F = circuit.jacobian([r, phi], wrt={0}, method="F").flat
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
-
-        # differentiate with respect to parameter phi
-        res_F = circuit.jacobian([r, phi], wrt={1}, method="F").flat
-        #expected_gradient = hermite_coeffs **2 * 1j*2**(-n)*np.abs(np.tanh(r))**n * sech(r) / gamma(n)
-        #print(circuit(r, phi), circuit.jacobian([r, phi], wrt={1}, method="F"), expected_gradient)
-        #assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
     def test_analytic_diff_error(self, tol):
         """Test that the analytic gradients are not supported when returning

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -731,7 +731,7 @@ class TestProbability:
         res_F = circuit.jacobian(params, method="F")
         assert np.allclose(res_F[:,0], diff_a, atol=tol, rtol=0)
         #assert np.allclose(res_F[:,1], partial_phi, atol=tol, rtol=0)
-=======
+
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to
         calculations for the NumberOperator"""

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -790,6 +790,23 @@ class TestProbability:
         #print(circuit(r, phi), circuit.jacobian([r, phi], wrt={1}, method="F"), expected_gradient)
         #assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
+    def test_analytic_diff_error(self, tol):
+        """Test that the analytic gradients are not supported when returning
+        Fock state probabilities."""
+        cutoff = 10
+
+        dev = qml.device("strawberryfields.fock", wires=1, cutoff_dim=cutoff)
+
+        @qml.qnode(dev)
+        def circuit(a, phi):
+            qml.Displacement(a, phi, wires=0)
+            return qml.probs(wires=[0])
+
+        a = 0.4
+        phi = -0.12
+        with pytest.raises(ValueError, match="Analytic gradients are not supported for circuits extracting Fock state probabilities"):
+            res_F = circuit.jacobian([a, phi], wrt={0}, method="A").flat
+
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to
         calculations for the NumberOperator"""

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -804,7 +804,7 @@ class TestProbability:
 
         a = 0.4
         phi = -0.12
-        with pytest.raises(ValueError, match="Analytic gradients are not supported for circuits extracting Fock state probabilities"):
+        with pytest.raises(ValueError, match="The analytic gradient method cannot be used"):
             res_F = circuit.jacobian([a, phi], wrt={0}, method="A").flat
 
     def test_tensorn_one_mode_is_mean_photon(self, tol):

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -453,25 +453,6 @@ class TestExpectation:
             circuit(), SF_expectation_reference(sf_expectation, wires), atol=tol, rtol=0
         )
 
-    def test_tensor_number_operator_raises(self, tol):
-        """Test that an error is raised if the TensorN is used for more than 2
-        wires with the Gaussian device."""
-        dev = qml.device("strawberryfields.gaussian", wires=3)
-
-        gate_name = "TensorN"
-        assert dev.supports_observable(gate_name)
-
-        op = qml.TensorN
-        sf_expectation = dev._observable_map[gate_name]
-        wires = [0, 1, 2]
-
-        @qml.qnode(dev)
-        def circuit():
-            return qml.expval(op(wires=wires))
-
-        with pytest.raises(ValueError, match="The number_expectation method only supports one or two modes for Gaussian states."):
-            circuit()
-
     @pytest.mark.parametrize("gate_name,op", [("X", qml.X), ("P", qml.P)])
     def test_quadrature(self, gate_name, op, tol):
         """Test that the expectation of the X and P quadrature operators yield
@@ -735,22 +716,3 @@ class TestProbability:
         gradF = circuit.jacobian([n, a], method="F")
         expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
         assert np.allclose(gradF, expected, atol=tol, rtol=0)
-
-    def test_tensor_number_operator_raises(self, tol):
-        """Test that the variance of the TensorN observable
-        is not supported"""
-        dev = qml.device("strawberryfields.gaussian", wires=2)
-
-        gate_name = "TensorN"
-        assert dev.supports_observable(gate_name)
-
-        op = qml.TensorN
-        sf_expectation = dev._observable_map[gate_name]
-        wires = [0, 1]
-
-        @qml.qnode(dev)
-        def circuit():
-            return qml.var(op(wires=wires))
-
-        with pytest.raises(ValueError, match="TensorN does not support variances."):
-            circuit()

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -688,6 +688,33 @@ class TestProbability:
         res = circuit(a, phi)
         assert np.allclose(res, ref_probs, atol=tol, rtol=0)
 
+    def test_finite_diff_coherent(self, tol):
+        """Test that the jacobian of the probability for a coherent states is
+        approximated well with finite differences"""
+        cutoff = 10
+
+        dev = qml.device("strawberryfields.gaussian", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(a, phi):
+            qml.Displacement(a, phi, wires=0)
+            return qml.probs(wires=[0])
+
+        a = 0.4
+        phi = -0.12
+
+        n = np.arange(cutoff)
+
+        # differentiate with respect to parameter a
+        res_F = circuit.jacobian([a, phi], wrt={0}, method="F").flat
+        expected_gradient = 2 * np.exp(-a ** 2) * a ** (2 * n - 1) * (n - a ** 2) / fac(n)
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+
+        # differentiate with respect to parameter phi
+        res_F = circuit.jacobian([a, phi], wrt={1}, method="F").flat
+        expected_gradient = 0
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to
         calculations for the NumberOperator"""

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -598,3 +598,4 @@ class TestVariance:
         gradF = circuit.jacobian([n, a], method="F")
         expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
         assert np.allclose(gradF, expected, atol=tol, rtol=0)
+

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -760,7 +760,7 @@ class TestProbability:
         a = 0.4
         phi = -0.12
 
-        with pytest.raises(ValueError, match="Analytic gradients are not supported for circuits extracting Fock state probabilities"):
+        with pytest.raises(ValueError, match="The analytic gradient method cannot be used with"):
             res_F = circuit.jacobian([a, phi], wrt={0}, method="A").flat
 
     def test_tensorn_one_mode_is_mean_photon(self, tol):

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -20,6 +20,7 @@ import strawberryfields as sf
 
 import pennylane as qml
 from pennylane import numpy as np
+from scipy.special import factorial as fac
 
 
 psi = np.array(
@@ -599,3 +600,68 @@ class TestVariance:
         expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
         assert np.allclose(gradF, expected, atol=tol, rtol=0)
 
+
+class TestProbability:
+    """Integration tests for returning probabilities"""
+
+    def test_single_mode_probability(self, tol):
+        """Test that a coherent state returns the correct probability"""
+        dev = qml.device("strawberryfields.gaussian", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(a, phi):
+            qml.Displacement(a, phi, wires=0)
+            return qml.probs(wires=0)
+
+        a = 0.4
+        phi = -0.12
+        cutoff = 10
+
+        alpha = a * np.exp(1j * phi)
+        n = np.arange(cutoff)
+        ref_probs = np.abs(np.exp(-0.5 * np.abs(alpha) ** 2) * alpha ** n / np.sqrt(fac(n))) ** 2
+
+        res = circuit(a, phi)
+        assert np.allclose(res, ref_probs, atol=tol, rtol=0)
+
+    def test_multi_mode_probability(self, tol):
+        """Test that a product of coherent states returns the correct probability"""
+        dev = qml.device("strawberryfields.gaussian", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(a, phi):
+            qml.Displacement(a, phi, wires=0)
+            qml.Displacement(a, phi, wires=1)
+            return qml.probs(wires=[0, 1])
+
+        a = 0.4
+        phi = -0.12
+        cutoff = 10
+
+        alpha = a * np.exp(1j * phi)
+        n = np.arange(cutoff)
+        ref_probs = np.abs(np.exp(-0.5 * np.abs(alpha) ** 2) * alpha ** n / np.sqrt(fac(n))) ** 2
+        ref_probs = np.kron(ref_probs, ref_probs)
+
+        res = circuit(a, phi)
+        assert np.allclose(res, ref_probs, atol=tol, rtol=0)
+
+    def test_marginal_probability(self, tol):
+        """Test that a coherent state marginal probability is correct"""
+        dev = qml.device("strawberryfields.gaussian", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(a, phi):
+            qml.Displacement(a, phi, wires=1)
+            return qml.probs(wires=1)
+
+        a = 0.4
+        phi = -0.12
+        cutoff = 10
+
+        alpha = a * np.exp(1j * phi)
+        n = np.arange(cutoff)
+        ref_probs = np.abs(np.exp(-0.5 * np.abs(alpha) ** 2) * alpha ** n / np.sqrt(fac(n))) ** 2
+
+        res = circuit(a, phi)
+        assert np.allclose(res, ref_probs, atol=tol, rtol=0)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -747,6 +747,22 @@ class TestProbability:
         expected_gradient = 0
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
+    def test_analytic_diff_error(self, tol):
+        """Test that the analytic gradients are not supported when returning
+        Fock state probabilities."""
+        dev = qml.device("strawberryfields.gaussian", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(a, phi):
+            qml.Displacement(a, phi, wires=0)
+            return qml.probs(wires=[0])
+
+        a = 0.4
+        phi = -0.12
+
+        with pytest.raises(ValueError, match="Analytic gradients are not supported for circuits extracting Fock state probabilities"):
+            res_F = circuit.jacobian([a, phi], wrt={0}, method="A").flat
+
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to
         calculations for the NumberOperator"""

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -706,7 +706,7 @@ class TestProbability:
 
         res = circuit(a, phi)
         assert np.allclose(res, ref_probs, atol=tol, rtol=0)
-=======
+
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to
         calculations for the NumberOperator"""


### PR DESCRIPTION
**Description of the Change:**

* Adds a new `StrawberryFieldsSimulator.probability()` method that returns the probability (up to a defined cutoff) of the state or reduced state.

* Fixes the `expectations.py` file, by changing `GaussianState` to `BaseGaussianState`, and removing deprecated code.

* Changes `requirements.txt` to install master Strawberry Fields

**Benefits:**

* Enables support for `qml.prob` for both the Fock and Gaussian devices

* Finite difference _should_ work, but need to check it. Parameter shift shouldn't work! Also need to check this.

  Edit: looks like we need to add the following to the `BaseQNode` in PennyLane-Core:

  ```python
  elif res.return_type is ObservableReturnTypes.Probability:
      self.output_conversion = np.squeeze
      self.output_dim = 2 ** len(res.wires)

      if self.model == "cv":
          self.output_dim = getattr(self.device, "cutoff", 10)
  ```

**Possible Drawbacks:**

* The `pennylane.Device` class still requires that the probability be returned as an ordered dictionary. (EDIT Antal: added this to our list of potential changes to the Device class)

* The `gaussian` device should now accept `cutoff` as an _optional_ keyword argument on device load.

* It looks like there is a bug in SF master --- SF won't import if TF is not installed.

**Related GitHub Issues:**
